### PR TITLE
Add SIPPeerStatus api

### DIFF
--- a/ami/confbridge.go
+++ b/ami/confbridge.go
@@ -8,7 +8,7 @@ func ConfbridgeList(client Client, actionID string, conference string) ([]Respon
 }
 
 // ConfbridgeListRooms lists data about all active conferences.
-func CConfbridgeKickonfbridgeListRooms(client Client, actionID string) ([]Response, error) {
+func ConfbridgeListRooms(client Client, actionID string) ([]Response, error) {
 	return requestList(client, "ConfbridgeListRooms", actionID, "ConfbridgeListRooms", "ConfbridgeListRoomsComplete")
 }
 

--- a/ami/sip.go
+++ b/ami/sip.go
@@ -28,6 +28,11 @@ func SIPShowPeer(client Client, actionID string, peer string) (Response, error) 
 	})
 }
 
+// SIPPeerStatus shows all SIP peer statuses.
+func SIPPeerStatus(client Client, actionID string) ([]Response, error) {
+	return requestList(client, "SIPpeerstatus", actionID, "PeerStatus", "SIPpeerstatusComplete")
+}
+
 // SIPShowRegistry shows SIP registrations (text format).
 func SIPShowRegistry(client Client, actionID string) ([]Response, error) {
 	return requestList(client, "SIPshowregistry", actionID, "RegistrationEntry", "RegistrationsComplete")


### PR DESCRIPTION
I added the SIPPeerStatus ami action, and fixed a typo in `confbridge.go`. 