### PR TITLE
fix: socket.Recv function doesn't returns error when connection is lost

### DIFF
--- a/ami/socket.go
+++ b/ami/socket.go
@@ -63,7 +63,6 @@ func (s *Socket) Close(ctx context.Context) error {
 	case <-ctx.Done():
 		return s.terminate()
 	}
-	return nil
 }
 
 // Send sends data to socket using fprintf format.


### PR DESCRIPTION
Hi, when a command is waiting for response and the socket connection is lost (i.e. asterisk restarts ), the command stucks.
Added some code to notify to the Recv function when the connection is lost
