### PR TITLE
Return from goroutine  if receive EOF and empty message

### DIFF
--- a/ami/socket.go
+++ b/ami/socket.go
@@ -84,6 +84,9 @@ func (s *Socket) run(ctx context.Context, conn net.Conn) {
 	for {
 		msg, err := reader.ReadString('\n')
 		if err != nil {
+			if err == io.EOF && len(msg) == 0 {
+				return
+			}
 			s.errors <- err
 			return
 		}


### PR DESCRIPTION
If make new connection like:
`socket, err :=  ami.NewSocket(ctx, host)`
And after work you make `ami.Logoff(ctx, socket, uuid)`
You can get goroutine leak, because:
goroutine `run` write to the channel `s.errors <- err`
but other code already end and nothing read this channel, and `run` waiting until read.
