### PR TITLE
fix: always return any kind of errors

### DIFF
--- a/ami/socket.go
+++ b/ami/socket.go
@@ -84,9 +84,6 @@ func (s *Socket) run(ctx context.Context, conn net.Conn) {
 	for {
 		msg, err := reader.ReadString('\n')
 		if err != nil {
-			if err == io.EOF && len(msg) == 0 {
-				return
-			}
 			s.errors <- err
 			return
 		}


### PR DESCRIPTION
It's just a rollback (in fact, this commit has already been done: e78fc8ac3f3a9c6da1e616269d4c2c76840f8039) in https://github.com/heltonmarx/goami/pull/41 which you missed.
Explanation: There are situations when we have a several strings from aster and first of them is 0-sized.